### PR TITLE
Add configs for TravisCI and Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - pip install -r requirements.txt
 - pip install -r test-requirements.txt
 - python setup.py build
-- pytnon setup.py install
+- python setup.py install
 
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
 install:
 - pip install -r requirements.txt
 - pip install -r test-requirements.txt
+- python setup.py build
+- pytnon setup.py install
 
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
 
 # command to run tests
 script:
-- tox
+- py.test -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+
+install:
+- pip install -r requirements.txt
+- pip install -r test-requirements.txt
+
+# command to run tests
+script:
+- tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ install:
 build_script:
   # Build the compiled extension
   - "python setup.py build"
+  - "python setup.py install"
 
 test_script:
   # Run the project tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ build_script:
 
 test_script:
   # Run the project tests
-  - "tox"
+  - py.test -s
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,49 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "64"
+
+install:
+  # Install Python (from the official .msi of http://python.org) and pip when
+  # not already installed.
+  # - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+
+  - "pip install -r requirements.txt"
+  - "pip install -r test-requirements.txt"
+
+build_script:
+  # Build the compiled extension
+  - "python setup.py build"
+
+test_script:
+  # Run the project tests
+  - "tox"
+
+after_test:
+  # If tests are successful, create binary packages for the project.
+  - "python setup.py bdist_wheel"
+  - "python setup.py bdist_wininst"
+  - "python setup.py bdist_msi"
+  - ps: "ls dist"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: dist\*
+
+#on_success:
+#  - TODO: upload the content of dist/*.whl to a public wheelhouse
+#
+

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 pytest>=2.7.2
 flake8>=2.3.0
 pylint>=1.7.1
-tox>=2.9.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest>=2.7.2
 flake8>=2.3.0
 pylint>=1.7.1
+tox>=2.9.1

--- a/test/test_hdrhistogram.py
+++ b/test/test_hdrhistogram.py
@@ -811,7 +811,7 @@ def hex_dump(label, str):
 
 @pytest.mark.basic
 def test_get_value_at_percentile():
-    histogram = HdrHistogram(LOWEST, 3600000000L, 3)
+    histogram = HdrHistogram(LOWEST, 3600000000, 3)
     histogram.record_value(1)
     histogram.record_value(2)
     assert histogram.get_value_at_percentile(50.0) == 1


### PR DESCRIPTION
TravisCI can handle Linux-based testing (potentially adding MacOS in the future), Appveyor should handle Windows-based testing.

Builds in my fork (dmand/HdrHistogram_py) are pointed to my accounts (https://travis-ci.org/dmand/HdrHistogram_py/builds) and (https://ci.appveyor.com/project/dmand/hdrhistogram-py). If merged, repo administrator should set up integration of CI results into the pull requests and branches.

Unfortunately, Appveyor tests currently fail because Appveyor uses 32-bit base boxes and tests do crash on 32-bit systems. So either Appveyor has to be disabled for now, or tests should be fixed for win32.

Future plans for CI support include running tests on Travis's Mac OS boxes (possibly in other pull request), resolving Windows situation and possibly building wheel distributions and uploading them to PyPI. The last one would be *really* nice to have.