### PR TITLE
Add csv output

### DIFF
--- a/hdrh/histogram.py
+++ b/hdrh/histogram.py
@@ -597,12 +597,21 @@ class HdrHistogram():
     def output_percentile_distribution(self,
                                        out_file,
                                        output_value_unit_scaling_ratio,
-                                       ticks_per_half_distance=5):
-        out_file.write(b'%12s %14s %10s %14s\n\n' %
-                       (b'Value', b'Percentile', b'TotalCount', b'1/(1-Percentile)'))
+                                       ticks_per_half_distance=5,
+                                       use_csv=False):
+        if use_csv:
+            out_file.write(b'"Value","Percentile","TotalCount","1/(1-Percentile)"\n')
+        else:
+            out_file.write(b'%12s %14s %10s %14s\n\n' %
+                           (b'Value', b'Percentile', b'TotalCount', b'1/(1-Percentile)'))
 
-        percentile_format = '%12.{}f %2.12f %10d %14.2f\n'.format(self.significant_figures)
-        last_line_percentile_format = '%12.{}f %2.12f %10d\n'.format(self.significant_figures)
+        if use_csv:
+            percentile_format = '%.{}f,%.12f,%d,%.2f\n'.format(self.significant_figures)
+            last_line_percentile_format = '%.{}f,%.12f,%d,Infinity\n'.format(self.significant_figures)
+        else:
+            percentile_format = '%12.{}f %2.12f %10d %14.2f\n'.format(self.significant_figures)
+            last_line_percentile_format = '%12.{}f %2.12f %10d\n'.format(self.significant_figures)
+
         for iter_value in self.get_percentile_iterator(ticks_per_half_distance):
             value = iter_value.value_iterated_to / output_value_unit_scaling_ratio
             percentile = iter_value.percentile_level_iterated_to / 100
@@ -615,6 +624,9 @@ class HdrHistogram():
                 out_file.write(last_line_percentile_format.encode() % (value,
                                                                        percentile,
                                                                        total_count))
+
+        if use_csv:
+            return
 
         mean = self.get_mean_value() / output_value_unit_scaling_ratio
         stddev = self.get_stddev()

--- a/test/test_hdrhistogram.py
+++ b/test/test_hdrhistogram.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 from builtins import range
 import cProfile
 import datetime
+import io
 import os
 import struct
 import zlib
@@ -49,6 +50,7 @@ from hdrh.log import HistogramLogReader
 from hdrh.codec import HdrPayload
 from hdrh.codec import HdrCookieException
 from hdrh.dump import dump
+
 
 def python_bitness():
     "cross-platform way of calculating bitness, returns either 32 or 64"
@@ -676,6 +678,16 @@ def test_tagged_v2_log_add():
 def test_output_percentile_distribution():
     histogram = load_histogram()
     histogram.output_percentile_distribution(open(os.devnull, 'wb'), 1000)
+
+@pytest.mark.log
+def test_output_percentile_distribution_csv():
+    buf = io.BytesIO()
+    histogram = load_histogram()
+    histogram.output_percentile_distribution(buf, 1000, use_csv=True)
+    lines = buf.getvalue().decode('utf-8').rstrip().split('\n')
+    assert lines[0] == '"Value","Percentile","TotalCount","1/(1-Percentile)"'
+    assert lines[1] == '1.000,0.000000000000,10000,1.00'
+    assert lines[-1] == '100007.935,1.000000000000,10001,Infinity'
 
 
 ARRAY_SIZE = 10

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, py38, pep8, lint
+envlist = py27, py36, py37, py38, py39, pep8, lint
 
 [testenv:pep8]
 commands = flake8 hdrh test


### PR DESCRIPTION
This adds a `use_csv=<bool>` keyword parameter to the `Histogram.output_percentile_distribution` method, with the CSV format matching the [Java implementation](https://github.com/HdrHistogram/HdrHistogram/blob/master/src/main/java/org/HdrHistogram/AbstractHistogram.java#L1779).

Example:
```python
histogram.output_percentile_distribution(sys.stdout.buffer, 1000, use_csv=True)
```
Result:
```
"Value","Percentile","TotalCount","1/(1-Percentile)"
1.000,0.000000000000,10000,1.00
1.000,0.100000000000,10000,1.11
1.000,0.190000000000,10000,1.23
<snip>
1.000,0.999895504324,10000,9569.77
100007.935,0.999905953891,10001,10633.08
100007.935,1.000000000000,10001,Infinity
```
The inverse percentile column contains `Infinity` to match the Java version.
