### PR TITLE
use correct homepage for pypi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description-file =
     README.rst
 author = Alec Hothan
 author-email = ahothan@gmail.com
-home-page = https://github.com/ahothan/hdrhistogram
+home-page = https://github.com/HdrHistogram/HdrHistogram_py
 classifier =
     Intended Audience :: Developers
     Intended Audience :: Information Technology


### PR DESCRIPTION
Hi, I noticed the homepage link at https://pypi.org/project/hdrhistogram/ is incorrect. This should fix it when the next release is made.