### PR TITLE
Fix integer overflow in decoding

### DIFF
--- a/src/python-codec.c
+++ b/src/python-codec.c
@@ -364,7 +364,7 @@ static PyObject *py_hdr_decode(PyObject *self, PyObject *args) {
             }
         }
     }
-    return Py_BuildValue("{s:i,s:i,s:i}",
+    return Py_BuildValue("{s:L,s:L,s:L}",
                         "total", total_count,
                         "min_nonzero_index", min_nonzero_index,
                         "max_nonzero_index", max_nonzero_index);
@@ -457,7 +457,7 @@ static PyObject *py_hdr_add_array(PyObject *self, PyObject *args) {
         PyErr_SetString(PyExc_ValueError, "Invalid word size");
         return NULL;
     }
-    return Py_BuildValue("i", total_count);
+    return Py_BuildValue("L", total_count);
 }
 
 #define ENCODE_DOCSTRING "Encode a counts array into a V2 varint buffer"


### PR DESCRIPTION
`total_count` is a uint64_t in the c code:

https://github.com/HdrHistogram/HdrHistogram_py/blob/25e180a5182f1019d4ae3da7c59b3af2a222a83a/src/python-codec.c#L279

But it was converted to a int when returning to Python:

https://github.com/HdrHistogram/HdrHistogram_py/blob/25e180a5182f1019d4ae3da7c59b3af2a222a83a/src/python-codec.c#L367-L370

It should be returned as a `long long` as well. Otherwise it will overflow, causing the problem stated in #38 .