### PR TITLE
Fix `dump_hdrh` executable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages =
 
 [entry_points]
 console_scripts =
-    dump_hdrh = hdrh.dump:main
+    dump_hdrh = hdrh.dump:dump
 
 [wheel]
 universal = 1


### PR DESCRIPTION
Changed the setup scripts to correctly install `dump_hdrh`.