### PR TITLE
Set explicit ctypes layout for packed headers

### DIFF
--- a/hdrh/codec.py
+++ b/hdrh/codec.py
@@ -79,6 +79,7 @@ class HdrHistogramSettingsException(Exception):
 # External encoding header
 class ExternalHeader(BigEndianStructure):
     _pack_ = 1
+    _layout_ = "ms"
     _fields_ = [
         ("cookie", c_uint),
         ("length", c_uint)]
@@ -89,6 +90,7 @@ ext_header_size = ctypes.sizeof(ExternalHeader)
 # Header for the zlib compressed part
 class PayloadHeader(BigEndianStructure):
     _pack_ = 1
+    _layout_ = "ms"
     _fields_ = [
         ("cookie", c_uint),
         ("payload_len", c_uint),

--- a/test/test_hdrhistogram.py
+++ b/test/test_hdrhistogram.py
@@ -46,8 +46,10 @@ from pyhdrh import decode     # pylint: disable=no-name-in-module,import-error
 from hdrh.histogram import HdrHistogram
 from hdrh.log import HistogramLogWriter
 from hdrh.log import HistogramLogReader
+from hdrh.codec import ExternalHeader
 from hdrh.codec import HdrPayload
 from hdrh.codec import HdrCookieException
+from hdrh.codec import PayloadHeader
 from hdrh.dump import dump
 
 
@@ -63,6 +65,11 @@ SIGNIFICANT = 3
 TEST_VALUE_LEVEL = 4
 INTERVAL = 10000
 BITNESS = python_bitness()
+
+@pytest.mark.codec
+def test_codec_headers_use_explicit_packed_layout():
+    assert ExternalHeader._layout_ == "ms"
+    assert PayloadHeader._layout_ == "ms"
 
 @pytest.mark.basic
 def test_basic():


### PR DESCRIPTION
## Summary

Fixes the Python port side of HdrHistogram/HdrHistogram#216.

Python 3.14 warns when a `ctypes` structure sets `_pack_` without also declaring `_layout_`, because that implicitly selects the MSVC-compatible layout on non-Windows platforms. The histogram wire-format headers already rely on packed layout, so this makes the existing choice explicit for `ExternalHeader` and `PayloadHeader` with `_layout_ = ms`.

I also added a small regression assertion so the intended layout stays visible.

## Validation

- `git diff --check HEAD~1..HEAD`

Not run locally.

## Notes

The original issue was opened in the main Java repository, but the warning comes from this Python port's `hdrh/codec.py`.