### PR TITLE
Drop Intel macOS (macos-13) from the release build matrix

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,9 +22,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 = Intel (x86_64), macos-14 = Apple silicon (arm64).
-        # macos-11 was removed by GitHub on 2024-06-28.
-        os: [ubuntu-24.04, windows-2022, macos-13, macos-14]
+        # macos-14 = Apple silicon (arm64). Intel macOS (macos-13) is
+        # dropped: that runner pool is being wound down by GitHub and
+        # queues unreliably, blocking releases. Intel macOS users build
+        # from the sdist. macos-11 was removed by GitHub on 2024-06-28.
+        os: [ubuntu-24.04, windows-2022, macos-14]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The macos-13 (Intel) runner pool is being wound down by GitHub and queues unreliably; a single macos-13 leg sat queued for ~30 minutes while every other build finished, blocking upload_pypi (which needs all build_wheels matrix legs) and stalling the PyPI publish indefinitely.

Build macOS wheels only on macos-14 (arm64). Intel macOS users install from the source distribution (which requires a C compiler), matching the README guidance.